### PR TITLE
Fixed offsetX:firstChild bug

### DIFF
--- a/assets/less/bootstrap/mixins.less
+++ b/assets/less/bootstrap/mixins.less
@@ -627,7 +627,7 @@
 
     .offsetX (@index) when (@index > 0) {
       (~".offset@{index}") { .offset(@index); }
-      .offset@{index}:first-child { .offsetFirstChild(@index); }
+      (~".offset@{index}:first-child") { .offsetFirstChild(@index); }
       .offsetX(@index - 1);
     }
     .offsetX (0) {}


### PR DESCRIPTION
The bug led to a '.row-fluid :firstChild' style that affected every first child (issue #274).
The resulting css is now equivalent with the corresponding elements in bootstrap.css v.2.3.2.
