### PR TITLE
Stripping script/style urls only of version info

### DIFF
--- a/lib/scripts.php
+++ b/lib/scripts.php
@@ -101,8 +101,7 @@ function shoestrap_jquery_local_fallback($src, $handle) {
 }
 
 function shoestrap_remove_script_version( $src ){
-  $parts = explode( '?', $src );
-  return $parts[0];
+  return preg_replace('/[?&]ver=[0-9a-z._-]*($|#|&)/i', '$1', $src);
 }
 add_filter( 'script_loader_src', 'shoestrap_remove_script_version', 15, 1 );
 add_filter( 'style_loader_src', 'shoestrap_remove_script_version', 15, 1 );


### PR DESCRIPTION
The previous version of this function removed all parameters. This meant that any scripts/styles requiring additional parameters (e.g.  the styling of All-in-one Event Calendar plugin) failed to load.
