### PR TITLE
Minor link fix

### DIFF
--- a/lib/modules/core.jumbotron/module.php
+++ b/lib/modules/core.jumbotron/module.php
@@ -33,7 +33,7 @@ function shoestrap_module_jumbotron_options($sections) {
                     is an area in your site where you can display in a prominent position things that matter to you.
                     This can be a slideshow, some text or whatever else you wish.
                     This area is implemented as a widget area, so in order for something to be displayed
-                    you will have to add a widget from <a href=\'$url\'>here</a>.', 'shoestrap' ),
+                    you will have to add a widget from <a href=\''.$url.'\'>here</a>.', 'shoestrap' ),
     'type'      => 'info'
   );
 


### PR DESCRIPTION
Jumbotron's Redux page was displaying a link to the widget page
incorrectly.
