### PR TITLE
Minor link fixes and warning fix

### DIFF
--- a/lib/modules/core.header/module.php
+++ b/lib/modules/core.header/module.php
@@ -16,8 +16,8 @@ function shoestrap_module_header_options( $sections ) {
   $fields[] = array( 
     'id'          => 'help9',
     'title'       => __( 'Extra Branding Area', 'shoestrap' ),
-    'desc'        => __( 'You can enable an extra branding/header area. In this header you can add your logo, and any other widgets you wish.
-                      To add widgets on your header, visit <a href=\'$url\'>this page</a> and add your widgets to the <strong>Header</strong> Widget Area.', 'shoestrap' ),
+    'desc'        => __( "You can enable an extra branding/header area. In this header you can add your logo, and any other widgets you wish.
+                      To add widgets on your header, visit <a href='$url'>this page</a> and add your widgets to the <strong>Header</strong> Widget Area.", 'shoestrap' ),
     'type'        => 'info',
     'required'    => array('advanced_toggle','=',array('1'))
   );

--- a/lib/modules/core.images/functions.images.php
+++ b/lib/modules/core.images/functions.images.php
@@ -51,7 +51,7 @@ function shoestrap_remove_featured_image_per_post_type() {
   $post_type_options = shoestrap_getVariable( 'feat_img_per_post_type' );
 
   foreach ( $post_types as $post_type ) :
-    if ( isset( $post_type ) && is_singular( $post_type ) && $post_type_options[$post_type] != 1 ) :
+    if ( isset( $post_type ) && is_singular( $post_type ) && isset( $post_type_options[$post_type] ) && $post_type_options[$post_type] != 1 ) :
       add_action( 'shoestrap_page_pre_content', 'shoestrap_featured_image' );
       add_action( 'shoestrap_single_pre_content', 'shoestrap_featured_image' );
       add_action( 'shoestrap_after_entry_meta', 'shoestrap_featured_image' );

--- a/lib/modules/core.jumbotron/module.php
+++ b/lib/modules/core.jumbotron/module.php
@@ -29,11 +29,11 @@ function shoestrap_module_jumbotron_options($sections) {
   $fields[] = array(
     'id'        => 'help8',
     'title'     => __( 'Jumbotron', 'shoestrap'),
-    'desc'      => __( 'A \'Jumbotron\', also known as \'Hero\' area,
+    'desc'      => __( "A 'Jumbotron', also known as 'Hero' area,
                     is an area in your site where you can display in a prominent position things that matter to you.
                     This can be a slideshow, some text or whatever else you wish.
                     This area is implemented as a widget area, so in order for something to be displayed
-                    you will have to add a widget from <a href=\'$url\'>here</a>.', 'shoestrap' ),
+                    you will have to add a widget from <a href='$url'>here</a>.", 'shoestrap' ),
     'type'      => 'info'
   );
 

--- a/lib/modules/core.menus/module.php
+++ b/lib/modules/core.menus/module.php
@@ -16,9 +16,9 @@ function shoestrap_module_menus_options( $sections ) {
   $fields[] = array( 
     'id'          => 'help7',
     'title'       => __( 'Advanced NavBar Options', 'shoestrap' ),
-    'desc'        => __( 'You can activate or deactivate your Primary NavBar here, and define its properties.
-                      Please note that you might have to manually create a menu if it doesn\'t already exist
-                      and add items to it from <a href=\'$url\'>this page</a>.', 'shoestrap' ),
+    'desc'        => __( "You can activate or deactivate your Primary NavBar here, and define its properties.
+                      Please note that you might have to manually create a menu if it doesn't already exist
+                      and add items to it from <a href='$url'>this page</a>.", 'shoestrap' ),
     'type'        => 'info'
   );
 


### PR DESCRIPTION
Fixed links in option descriptions by using double quotes instead of
single quotes - see php manual about variable expansion in strings. Also
prevented "Warning: Illegal string offset 'page' in
core.images/functions.images.php line 54"
