### PR TITLE
Update functions.metaconfig.php

### DIFF
--- a/lib/modules/core.entry-meta/functions.metaconfig.php
+++ b/lib/modules/core.entry-meta/functions.metaconfig.php
@@ -45,7 +45,7 @@ function shoestrap_meta_custom_render() {
   // Distribute meta elements over 12 columns
   $elementscountplus = strlen( $elementscountplus );
   if ( $elementscountplus >= 2 ) :
-    $col = round( ( 12 / ( $elementscountplus ) ), 0, PHP_ROUND_HALF_DOWN );
+    $col = round( ( 12 / ( $elementscountplus ) ), 0);
   else :
     $col = 12;
   endif;


### PR DESCRIPTION
Fix for Warning Issue https://github.com/shoestrap/shoestrap/issues/402

Warning: Wrong parameter count for round() lib/modules/core.entry-meta/functions.metaconfig.php on line 48

PHP versions lower than 5.3 show a warning about this use of round. In 5.3's version of "round()" it uses a 3rd parameter. Removing the 3rd parameter makes the warning go away in 5.2
