### PR TITLE
Update Less.php

### DIFF
--- a/lib/modules/core.compiler/less.php/Less.php
+++ b/lib/modules/core.compiler/less.php/Less.php
@@ -6202,7 +6202,7 @@ class Less_CompilerException extends Exception {
 	private $filename;
 
 	public function __construct($message = null, $code = 0, Exception $previous = null, $filename = null) {
-		parent::__construct($message, $code, $previous);
+		parent::__construct($message, $code);
 		$this->filename = $filename;
 	}
 


### PR DESCRIPTION
Another fix for compatibility for PHP versions lower than 5.3.

Got error when saving settings from Shoestrap settings menu under PHP 5.2.x

Wrong parameters for Exception([string $exception [, long $code ] less.php 6205

change

```
parent::__construct($message, $code, $previous);
```

to

```
parent::__construct($message, $code);
```

Not sure if this changes anything else, but it gets rid of the error for me on php 5.2.17
