### PR TITLE
Fixed inline style generation of header margin.

### DIFF
--- a/lib/modules/core.header/functions.header.php
+++ b/lib/modules/core.header/functions.header.php
@@ -61,7 +61,7 @@ function shoestrap_header_css() {
   if ( shoestrap_getVariable( 'header_toggle' ) == 1 ) {
     $style = '.header-wrapper{ color: '.$cl.';';
 
-    $style .= ( $opacity != 1 && $opacity != '' ) ? 'background: rgb('.$rgb.'); background: rgba('.$rgb.', '.$opacity.');' : $style .= 'background: '.$bg.';';
+    $style .= ( $opacity != 1 && $opacity != '' ) ? 'background: rgb('.$rgb.'); background: rgba('.$rgb.', '.$opacity.');' : 'background: '.$bg.';';
     $style .= 'margin-top:'.$header_margin_top.'px; margin-bottom:'.$header_margin_bottom.'px; }';
 
     wp_add_inline_style( 'shoestrap_css', $style );


### PR DESCRIPTION
By editing the Theme Options and under Extra Header, you are able to choose a custom value for the Header Top and Bottom Margin among other properties. In case Opacity is not set or is 100%, the inline style gets corrupted by a duplicate part. This commit fixes this issue.
