### PR TITLE
Fixed inline body background repeat css generation.

### DIFF
--- a/lib/modules/background/functions.background.php
+++ b/lib/modules/background/functions.background.php
@@ -29,7 +29,7 @@ function shoestrap_background_css() {
 	$content_bg .= ( $content_opacity != 100 ) ? 'background:' . shoestrap_get_rgba( $content_bg, $content_opacity ) . ';' : '';
 
 	$repeat  = ( !in_array( $repeat, array( 'no-repeat', 'repeat-x', 'repeat-y', 'repeat' ) ) ) ? 'repeat' : $repeat;
-	$repeat .= ( $repeat == 'no-repeat' ) ? 'background-size: auto;' : $repeat;
+	$repeat .= ( $repeat == 'no-repeat' ) ? 'background-size: auto;' : '';
 
 	$position = ( !in_array( $position, array( 'center', 'right', 'left' ) ) ) ? 'left' : $position;
 


### PR DESCRIPTION
When setting a background image on Theme Options and you also set the background to repeat, the inline CSS generated results in "background-repeat: repeatrepeat" thus the style is not applied. This commit fixes the referred issue.

Please refer to https://github.com/shoestrap/shoestrap-3/pull/482

Thanks!
