### PR TITLE
Easier to change name of theme

### DIFF
--- a/framework/bootstrap/includes/class-Shoestrap_Options.php
+++ b/framework/bootstrap/includes/class-Shoestrap_Options.php
@@ -1859,8 +1859,8 @@ if ( ! class_exists( 'Shoestrap_Options' ) ) {
 				'display_version'   => $theme->get( 'Version' ),
 				'menu_type'         => 'menu',
 				'allow_sub_menu'    => true,
-				'menu_title'        => __( 'Shoestrap', 'shoestrap'),
-				'page_title'        => __('Shoestrap Options', 'shoestrap'),
+				'menu_title'        => $theme->get( 'Name' ),
+				'page_title'        => $theme->get( 'Name' ) .  __(' Options', 'shoestrap'),
 				'global_variable'   => 'redux',
 
 				'google_api_key'    => 'AIzaSyCDiOc36EIOmwdwspLG3LYwCg9avqC5YLs',


### PR DESCRIPTION
One cannot change the name of the theme from Shoestrap (for custom theme) without changing source
These two commits fix this (other than style.css still could be overwritten).
