### PR TITLE
Fix for issue #593: Glyphicons fail to render + minor: avoid a PHP notice

### DIFF
--- a/framework/bootstrap/assets/less/vendor/bootstrap/variables.less
+++ b/framework/bootstrap/assets/less/vendor/bootstrap/variables.less
@@ -73,7 +73,7 @@
 //## Specify custom location and filename of the included Glyphicons icon font. Useful for those including Bootstrap via Bower.
 
 //** Load fonts from this directory.
-@icon-font-path:          "../fonts/";
+@icon-font-path:          "@{assets-url}/fonts/";
 //** File name for all font files.
 @icon-font-name:          "glyphicons-halflings-regular";
 //** Element ID within SVG icon file.

--- a/framework/bootstrap/class-SS_Framework_Bootstrap.php
+++ b/framework/bootstrap/class-SS_Framework_Bootstrap.php
@@ -985,7 +985,10 @@ if ( ! class_exists( 'SS_Framework_Bootstrap' ) ) {
 			try {
 
 				$parser = new Less_Parser( $options );
-
+                                $parser->ModifyVars(array(
+                                   'assets-url' =>  '"' . SHOESTRAP_ASSETS_URL . '"'
+                                ));
+                                
 				// The main app.less file
 				$parser->parseFile( $bootstrap_location . 'app.less', $bootstrap_uri );
 
@@ -1013,11 +1016,12 @@ if ( ! class_exists( 'SS_Framework_Bootstrap' ) ) {
 
 				// Add a filter to the compiler
 				$parser->parse( apply_filters( 'shoestrap_compiler', '' ) );
-
+                                
 				$css = $parser->getCss();
-
+                                
 			} catch( Exception $e ) {
 				$error_message = $e->getMessage();
+                                die($error_message);
 			}
 
 			// Below are just some ugly hacks.

--- a/lib/cleanup.php
+++ b/lib/cleanup.php
@@ -18,8 +18,10 @@ function shoestrap_head_cleanup() {
 	remove_action( 'wp_head', 'wp_shortlink_wp_head', 10, 0 );
 
 	global $wp_widget_factory;
-	remove_action( 'wp_head', array( $wp_widget_factory->widgets['WP_Widget_Recent_Comments'], 'recent_comments_style' ) );
-
+        if(array_key_exists('WP_Widget_Recent_Comments', $wp_widget_factory->widgets)) {
+            remove_action( 'wp_head', array( $wp_widget_factory->widgets['WP_Widget_Recent_Comments'], 'recent_comments_style' ) );
+        }
+	
 	if ( ! class_exists( 'WPSEO_Frontend' ) ) {
 		remove_action( 'wp_head', 'rel_canonical' );
 		add_action( 'wp_head', 'shoestrap_rel_canonical' );


### PR DESCRIPTION
--- Fix for issue #593: Glyphicons fail to render

The culprit is @icon-font-path, a relative path defined in variables.less. Its modification by the compiler and the fact that the CSS output is put elsewhere both make the path invalid, in the end. In class-SS_Framework_Bootstrap.php, I've defined a Less variable named @assets-url which contains the absolute URL to the assets folder. @assets-url is now used in variables.less to determine @icon-font-path

--- Minor: avoid a PHP notice if WP_Widget_Recent_Comments is inactive

In cleanup.php, check if WP_Widget_Recent_Comments is present before referring to it.
