### PR TITLE
navbar_social_links function should be is static

### DIFF
--- a/framework/bootstrap/class-SS_Framework_Bootstrap.php
+++ b/framework/bootstrap/class-SS_Framework_Bootstrap.php
@@ -1070,7 +1070,7 @@ if ( ! class_exists( 'SS_Framework_Bootstrap' ) ) {
 		/**
 		 * Build the social links for the navbar
 		 */
-		public function navbar_social_links() {
+		public static function navbar_social_links() {
 			global $ss_social;
 
 			// Get all the social networks the user is using


### PR DESCRIPTION
Warning will appear when display social links in secondary menu because navbar_social_links is called staticly and actually this function is not static
See class-Shoestrap_Menus.php line 262  [SS_Framework_Bootstrap::navbar_social_links();]
